### PR TITLE
[ready] Use pane instead of window for vimux

### DIFF
--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -56,7 +56,6 @@ autocmd BufWinLeave * call clearmatches()
 autocmd BufWritePre * :%s/\s\+$//e
 
 let g:vroom_use_vimux = 1
-let g:VimuxRunnerType = "window"
 
 noremap R "_d
 


### PR DESCRIPTION
Personally, I think leave VimuxRunnerType as 'pane' would be a better trade-off, as:
- Most of the time I don't really need to view test running in full screen.
- No limitation on where I have to open vim.
- I'm immediately notice that pressing '<leader>R' taking effect, since it opens a new pane under my current pane, and I can still view the test running without doing anything. I can decide to switch to that pane & zoom it out if I want to. Not like when we set VimuxRunnerType as 'window', I'm forcing to switch to the second pane to view the test running.