### PR TITLE
[ready] Use Janus default key binding to run test

### DIFF
--- a/janus/vim/vimrc
+++ b/janus/vim/vimrc
@@ -57,17 +57,14 @@ autocmd BufWinLeave * call clearmatches()
 
 autocmd BufWritePre * :%s/\s\+$//e
 
-" make test commands execute using vimux.vim
-let test#strategy = "vimux"
-nmap <silent> t<C-n> :TestNearest<CR> " t Ctrl+n
-nmap <silent> t<C-f> :TestFile<CR>    " t Ctrl+f
-nmap <silent> t<C-s> :TestSuite<CR>   " t Ctrl+s
-nmap <silent> t<C-l> :TestLast<CR>    " t Ctrl+l
-nmap <silent> t<C-g> :TestVisit<CR>   " t Ctrl+g
-
 noremap R "_d
 
 let mapleader = " "
+
+" make test commands execute using vimux.vim
+let test#strategy = "vimux"
+nmap <Leader>R :TestNearest<CR>
+nmap <Leader>r :TestFile<CR>
 
 if executable('ag')
   " Use ag over grep


### PR DESCRIPTION
I feel like we should keep Janus default key binding (`<Leader>R`, `<Leader>r`), it's much easier to type compare to vim-test. So under the hood it uses vim-test with better performance, but on the surface, nothing changes compare to Janus.